### PR TITLE
Modifying the pulse.util.intersects function to run its test differently.

### DIFF
--- a/lib/pulse/src/util.js
+++ b/lib/pulse/src/util.js
@@ -71,27 +71,11 @@ pulse.util.find = function(collection, name)
  */
 pulse.util.intersects = function(box1, box2)
 {
-  var points = [
-    {x: box1.x, y: box1.y},
-    {x: box1.x, y: box1.y + box1.height},
-    {x: box1.x + box1.width, y: box1.y},
-    {x: box1.x + box1.width, y: box1.y + box1.height}
-  ];
-
-  /** Loop through each point and determine if it
-   * falls within the other box's footprint. */
-  for(var p = 0; p < 4; p++)
-  {
-    var pnt = points[p];
-    if(pnt.x < box2.width && pnt.x > box2.x)
-    {
-      if(pnt.y < box2.height && pnt.y > box2.y)
-      {
-        return true;
-      }
-    }
+  /* Determin if the boxes overlap */
+  if (box1.x < box2.x+box2.width && box1.x+box1.width > box2.x &&
+    box1.y < box2.y+box2.height && box1.y+box1.height > box2.y) {
+    return true;
   }
-
   return false;
 };
 


### PR DESCRIPTION
Modifying the pulse.util.intersects function to test for rectangle overlapping instead of just checking the corner points.

Basically just using the accepted answer from this question. http://stackoverflow.com/questions/306316/determine-if-two-rectangles-overlap-each-other

Instead of using points it checks for the proof conditions in which two rectangles overlap.

This fixes instances where the rectangles are overlapping, but no corners are overlapping.
